### PR TITLE
Pyproject Python version lowered.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "poetry_python_project"}]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 pylint = "^2.17.0"
 black = "^23.1.0"
 requests = "^2.28.2"


### PR DESCRIPTION
Lowered Required Python Version in Pyproject

## Describe your changes
Lowered Required Python Version in Pyproject

## Non-obvious technical information
As there are not python projects that specifically only requires 3.11 or higher, allowed lower python versions up to 3.9 to be acceptable. 

## Checklist before requesting a review
- [v ] `make format` and `make lint` have been run and the output has been addressed.
- [v ] The code runs successfully.
