### PR TITLE
Add import sort package, isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BASEDIR="supreme_court_predictions"
 
 .PHONY: format
 format:
+	isort ${BASEDIR}/ test/ --line-length=80 --profile=black
 	black ${BASEDIR}/ test/ --line-length=80
 
 .PHONY: lint

--- a/poetry.lock
+++ b/poetry.lock
@@ -2246,4 +2246,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c3457e4cb9a116a4619ca62253945001f064a923f997a7de83121472d7ca3b01"
+content-hash = "99447961983cf9c5a760988214e74333418c6635e82ec57ec0b56ba726d05fef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pytest = "^7.2.2"
 responses = "^0.23.1"
 convokit = "^2.5.3"
 pandas = "^2.0.0"
+isort = "^5.12.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/supreme_court_predictions/statistics/datacleaner.py
+++ b/supreme_court_predictions/statistics/datacleaner.py
@@ -3,16 +3,16 @@ This file houses the class that is used to clean the convokit data and convert
 it to a usable format.
 """
 
-import os
 import json
+import os
+
 import pandas as pd
+from convokit import Corpus, download
 
 from supreme_court_predictions.util.contants import (
     ENCODING_UTF_8,
     ENCODING_UTF_8_SIG,
 )
-
-from convokit import Corpus, download
 
 
 class DataCleaner:


### PR DESCRIPTION
## Describe your changes
Added an import sorting plug-in to the package and then added its command to the `make format` command.

## Non-obvious technical information
Nay.

## Checklist before requesting a review
- [x] `make format` and `make lint` have been run and the output has been addressed.
- [x] The code runs successfully.

```
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % make format
isort "supreme_court_predictions"/ test/ --line-length=80 --profile=black
black "supreme_court_predictions"/ test/ --line-length=80
All done! ✨ 🍰 ✨
13 files left unchanged.
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % 
```
