### PR TITLE
Add text cleaning regex statements

### DIFF
--- a/supreme_court_predictions/statistics/datacleaner.py
+++ b/supreme_court_predictions/statistics/datacleaner.py
@@ -5,6 +5,7 @@ it to a usable format.
 
 import json
 import os
+import re
 
 import pandas as pd
 from convokit import Corpus, download
@@ -90,7 +91,7 @@ class DataCleaner:
         dict_list = []
         for speaker_key in list(speakers_dict.keys()):
             speaker_data = speakers_dict[speaker_key]["meta"]
-            speaker_data["speaker_key"] = speaker_key
+            speaker_data["speaker_key"] = re.sub(r"^j__", "", speaker_key)
             dict_list.append(speaker_data)
 
         df = pd.DataFrame(dict_list)
@@ -181,8 +182,12 @@ class DataCleaner:
             }
             utterance_text = utterance["text"]
             # TODO: More robust cleaning
-            clean_utterance = utterance_text.replace("\n", " ").strip()
-            clean_dict["text"] = clean_utterance
+            clean_utterance = utterance_text.lower()
+            no_newline = re.sub(r"[\r\n\t]", " ", clean_utterance)
+            no_bracket = re.sub(r"[\[\]\(\)-]", "", no_newline)
+
+            clean_dict["text"] = no_bracket
+
 
             clean_utterances_list.append(clean_dict)
 


### PR DESCRIPTION
## Describe your changes
This will first match newline, carriage return, and tab characters and replace them with a space. This will also replace brackets, "j__" at the beginning of the string, and then replace them with an empty string.
added lower()

Before, the words were stuck to each other. There were words that were stripped and stuck together such as word1word2. Now, the words are all separate. 

Names all start with j__ because they are justices. Those are all taken out. 

## Non-obvious technical information

## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] `make format` and `make lint` have been run and the output has been addressed.
- [x] The code runs successfully.

```
python -m "supreme_court_predictions" --clean-data
oh, what up?
Working in /Users/jessupjong/Dropbox/UChicago/Machine Learning/supreme-court-ml-predictions/supreme_court_predictions/data/convokit/
Data will be saved to /Users/jessupjong/Dropbox/UChicago/Machine Learning/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Corpus already downloaded
Parsing speakers...
Parsing conversations metadata...
Parsing utterances...
Data saved to /Users/jessupjong/Dropbox/UChicago/Machine Learning/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/

make format
isort "supreme_court_predictions"/ test/ --line-length=80 --profile=black
black "supreme_court_predictions"/ test/ --line-length=80
All done! ✨ 🍰 ✨
13 files left unchanged.

make lint
pylint "supreme_court_predictions"/ test/
************* Module supreme_court_predictions.__main__
supreme_court_predictions/__main__.py:1:0: C0103: Module name "__main__" doesn't conform to '^(_?[a-z][a-z0-9_]*|__init__)$' pattern (invalid-name)

-----------------------------------
Your code has been rated at 9.92/10
```
