### PR TITLE
Change speaker roles to speaker types

### DIFF
--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -207,10 +207,10 @@ class Descriptives:
         speakers = pd.read_csv(self.local_path + "speakers_df.csv")
 
         # Get descriptive stats
-        speakers_stats = self.get_count_desc(speakers, ["speaker_role"])
+        speakers_stats = self.get_count_desc(speakers, ["speaker_type"])
 
-        speaker_roles = ["inaudible (U)", "justice (J)", "unknown (A)"]
-        speakers_stats.index = self.fix_indices("speaker role", speaker_roles)
+        speaker_types = ["advocate (A)", "justice (J)", "unknown (U)"]
+        speakers_stats.index = self.fix_indices("speaker type", speaker_types)
 
         # Add count of unique speaker names and keys
         speakers_stats.loc[("speaker names", ""), :] = len(


### PR DESCRIPTION
## Describe your changes
In the descriptive statistics for speakers, I misclassified speaker types and speaker roles.

## Non-obvious technical information
NA


## Checklist before requesting a review
- [x] The code runs successfully.
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
- [x] The `Lint` GitHub Action step is passing.
  - Manually run `make format` to correct the errors.
