### PR TITLE
Update README.md and add `cases.jsonl` download function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Supreme Court ML Prediction Project
 The project uses historic United States Supreme Court cases to train natural language processing models to predict case rulings.
 
-### Project Assumptions
+### Project Assumptions and Things to Know
 1. The number of unique roles within the advocates' file is too numerous to be helpful, so we merged them into 5 categories. While this merger may remove some of the variability and nuance in the file, we believe it will make it easier to derive meaningful conclusions.
    - The groupings for the roles are as follows: `inferred`, `for respondent`, `for partitioner`, and `for amicus curiae`
    - The code for that grouping can be found in the `clean_roles` function in the [`descriptives.py` file.](https://github.com/michplunkett/supreme-court-ml-predictions/blob/main/supreme_court_predictions/statistics/descriptives.py)
+2. We are not using the [`Voting Information` file](https://convokit.cornell.edu/documentation/supreme.html#some-considerations-regarding-case-and-voting-information) in the current application state. This point is currently being addressed, and it will be added to the `get-data` part of the application within the next week.
+3. The current statistics model uses all the available data. Within the next week, we will change it to using just the first 5 years of the Roberts' court, starting on October 3, 2005, and ending on October 1, 2011.
 
 ### Project Requirements
 - Python version: `^3.11`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ The project uses historic United States Supreme Court cases to train natural lan
 1. The number of unique roles within the advocates' file is too numerous to be helpful, so we merged them into 5 categories. While this merger may remove some of the variability and nuance in the file, we believe it will make it easier to derive meaningful conclusions.
    - The groupings for the roles are as follows: `inferred`, `for respondent`, `for partitioner`, and `for amicus curiae`
    - The code for that grouping can be found in the `clean_roles` function in the [`descriptives.py` file.](https://github.com/michplunkett/supreme-court-ml-predictions/blob/main/supreme_court_predictions/statistics/descriptives.py)
-2. We are not using the [`Voting Information` file](https://convokit.cornell.edu/documentation/supreme.html#some-considerations-regarding-case-and-voting-information) in the current application state. This point is currently being addressed, and it will be added to the `get-data` part of the application within the next week.
-3. The current statistics model uses all the available data. Within the next week, we will change it to using just the first 5 years of the Roberts' court, starting on October 3, 2005, and ending on October 1, 2011.
+2. The current statistics model uses all the available data. Within the next week, we will change it to using just the first 5 years of the Roberts' court, starting on October 3, 2005, and ending on October 1, 2011.
 
 ### Project Requirements
 - Python version: `^3.11`

--- a/supreme_court_predictions/api/convokit/client.py
+++ b/supreme_court_predictions/api/convokit/client.py
@@ -1,16 +1,29 @@
 """
 This file serves as the client for convokit.
 """
+import requests
 from convokit import Corpus, download
+
+from supreme_court_predictions.util.contants import ENCODING_UTF_8
+
+# Constants
+DOWNLOAD_BASE_PATH = "./supreme_court_predictions/data/convokit/"
 
 
 def get_data():
     """
-    Loads and outputs the Supreme Court Corpus data
+    Loads and outputs the Supreme Court Corpus and case verdict data
     """
 
     print("Loading Supreme Court Corpus Data...")
     corpus = Corpus(filename=download("supreme-corpus"))
-    corpus.dump(
-        "supreme_corpus", base_path="./supreme_court_predictions/data/convokit/"
+    corpus.dump("supreme_corpus", base_path=DOWNLOAD_BASE_PATH)
+
+    r = requests.get(
+        url="https://zissou.infosci.cornell.edu/convokit"
+        "/datasets/supreme-corpus/cases.jsonl",
+        allow_redirects=True,
     )
+
+    with open(f"{DOWNLOAD_BASE_PATH}cases.jsonl", "w") as outfile:
+        outfile.write(r.content.decode(ENCODING_UTF_8))

--- a/supreme_court_predictions/statistics/datacleaner.py
+++ b/supreme_court_predictions/statistics/datacleaner.py
@@ -10,10 +10,7 @@ import re
 import pandas as pd
 from convokit import Corpus, download
 
-from supreme_court_predictions.util.contants import (
-    ENCODING_UTF_8,
-    ENCODING_UTF_8_SIG,
-)
+from supreme_court_predictions.util.contants import ENCODING_UTF_8
 
 
 class DataCleaner:
@@ -255,32 +252,32 @@ class DataCleaner:
             self.speakers_df.to_csv(
                 self.output_path + "/speakers_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
             self.conversations_df.to_csv(
                 self.output_path + "/conversations_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
             self.advocates_df.to_csv(
                 self.output_path + "/advocates_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
             self.voters_df.to_csv(
                 self.output_path + "/voters_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
             self.utterances_df.to_csv(
                 self.output_path + "/utterances_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
             self.cases_df.to_csv(
                 self.output_path + "/cases_df.csv",
                 index=False,
-                encoding=ENCODING_UTF_8_SIG,
+                encoding=ENCODING_UTF_8,
             )
 
             print("Data saved to " + self.output_path)

--- a/supreme_court_predictions/util/contants.py
+++ b/supreme_court_predictions/util/contants.py
@@ -4,4 +4,3 @@ This file holds constants that will be used throughout the application.
 
 # What is utf-8-sig? https://stackoverflow.com/a/60614459
 ENCODING_UTF_8 = "utf-8"
-ENCODING_UTF_8_SIG = "utf-8-sig"


### PR DESCRIPTION
## Describe your changes
I updated the `README` to reflect things the reviewer needs to know regarding upcoming application updates and added function to download and save the `cases.jsonl` file.

## Non-obvious technical information
Nay.

## Checklist before requesting a review
- [x] Manually validated the addition of the `cases.jsonl` file.

```
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % ls -al ./supreme_court_predictions/data/convokit
total 8
drwxr-xr-x  4 michaelp  staff  128 Apr 21 16:16 .
drwxr-xr-x  6 michaelp  staff  192 Apr  7 13:35 ..
-rw-r--r--  1 michaelp  staff  139 Apr  7 13:39 README.md
drwxr-xr-x  7 michaelp  staff  224 Apr  7 14:48 supreme_corpus
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % make get-data                                   
python -m "supreme_court_predictions" --get-data
oh, what up?
Loading Supreme Court Corpus Data...
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % ls -al ./supreme_court_predictions/data/convokit
total 26064
drwxr-xr-x  5 michaelp  staff       160 Apr 21 16:17 .
drwxr-xr-x  6 michaelp  staff       192 Apr  7 13:35 ..
-rw-r--r--  1 michaelp  staff       139 Apr  7 13:39 README.md
-rw-r--r--  1 michaelp  staff  13337468 Apr 21 16:17 cases.jsonl
drwxr-xr-x  7 michaelp  staff       224 Apr  7 14:48 supreme_corpus
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % head -n 2 ./supreme_court_predictions/data/convokit/cases.jsonl 
{"id": "1955_71", "year": 1955, "citation": "350 US 79", "title": "Affronti v. United States", "petitioner": "Affronti", "respondent": "United States", "docket_no": "71", "court": "Warren Court", "decided_date": "Dec 5, 1955", "url": "https://www.oyez.org/cases/1955/71", "transcripts": [{"name": "Oral Argument - November 15, 1955", "url": "https://apps.oyez.org/player/#/warren3/oral_argument_audio/13127", "id": 13127, "case_id": "1955_71"}], "adv_sides_inferred": true, "known_respondent_adv": true, "advocates": {"Harry F. Murphy": {"id": "harry_f_murphy", "name": "Harry F. Murphy", "side": 1}, "John V. Lindsay": {"id": "john_v_lindsay", "name": "John V. Lindsay", "side": 0}}, "win_side": 0.0, "win_side_detail": 2.0, "scdb_docket_id": "1955-009-01", "votes": {"j__john_m_harlan2": 2.0, "j__hugo_l_black": 2.0, "j__william_o_douglas": 2.0, "j__earl_warren": 2.0, "j__tom_c_clark": 2.0, "j__felix_frankfurter": 2.0, "j__harold_burton": 2.0, "j__stanley_reed": 2.0, "j__sherman_minton": 2.0}, "votes_detail": {"j__john_m_harlan2": 1.0, "j__hugo_l_black": 1.0, "j__william_o_douglas": 1.0, "j__earl_warren": 1.0, "j__tom_c_clark": 1.0, "j__felix_frankfurter": 1.0, "j__harold_burton": 1.0, "j__stanley_reed": 1.0, "j__sherman_minton": 1.0}, "is_eq_divided": false, "votes_side": {"j__john_m_harlan2": 0.0, "j__hugo_l_black": 0.0, "j__william_o_douglas": 0.0, "j__earl_warren": 0.0, "j__tom_c_clark": 0.0, "j__felix_frankfurter": 0.0, "j__harold_burton": 0.0, "j__stanley_reed": 0.0, "j__sherman_minton": 0.0}}
{"id": "1955_410", "year": 1955, "citation": "351 US 79", "title": "American Airlines, Inc. v. North American Airlines, Inc.", "petitioner": "American Airlines, Inc.", "respondent": "North American Airlines, Inc.", "docket_no": "410", "court": "Warren Court", "decided_date": "Apr 23, 1956", "url": "https://www.oyez.org/cases/1955/410", "transcripts": [{"name": "Oral Argument - March 07, 1956", "url": "https://apps.oyez.org/player/#/warren3/oral_argument_audio/12997", "id": 12997, "case_id": "1955_410"}, {"name": "Oral Argument - March 06, 1956", "url": "https://apps.oyez.org/player/#/warren3/oral_argument_audio/13024", "id": 13024, "case_id": "1955_410"}], "adv_sides_inferred": true, "known_respondent_adv": true, "advocates": {"Howard C. Westwood": {"id": "howard_c_westwood", "name": "Howard C. Westwood", "side": 1}, "Walter J. Derenberg": {"id": "walter_j_derenberg", "name": "Walter J. Derenberg", "side": 0}}, "win_side": 1.0, "win_side_detail": 4.0, "scdb_docket_id": "1955-071-01", "votes": {"j__john_m_harlan2": 2.0, "j__hugo_l_black": 2.0, "j__william_o_douglas": 1.0, "j__earl_warren": 2.0, "j__tom_c_clark": 2.0, "j__felix_frankfurter": 2.0, "j__harold_burton": 2.0, "j__stanley_reed": 1.0, "j__sherman_minton": 2.0}, "votes_detail": {"j__john_m_harlan2": 1.0, "j__hugo_l_black": 1.0, "j__william_o_douglas": 2.0, "j__earl_warren": 1.0, "j__tom_c_clark": 1.0, "j__felix_frankfurter": 1.0, "j__harold_burton": 1.0, "j__stanley_reed": 2.0, "j__sherman_minton": 1.0}, "is_eq_divided": false, "votes_side": {"j__john_m_harlan2": 1.0, "j__hugo_l_black": 1.0, "j__william_o_douglas": 0.0, "j__earl_warren": 1.0, "j__tom_c_clark": 1.0, "j__felix_frankfurter": 1.0, "j__harold_burton": 1.0, "j__stanley_reed": 0.0, "j__sherman_minton": 1.0}}
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % 
```

- [x] The `Lint` GitHub Action step is passing.
  - Manually run `make format` to correct the errors.
