### PR TITLE
Address Spacy `None` issue

### DIFF
--- a/supreme_court_predictions/statistics/tokenizer.py
+++ b/supreme_court_predictions/statistics/tokenizer.py
@@ -1,6 +1,6 @@
 """
-A module implementing a Tokenizer class that tokenizes text. 
-The Tokenizer class provides methods for initializing the required 
+A module implementing a Tokenizer class that tokenizes text.
+The Tokenizer class provides methods for initializing the required
 components and processing text data. It is designed to handle tokenization
 tasks efficiently and effectively in a user-friendly manner.
 """
@@ -59,8 +59,8 @@ class Tokenizer:
         """
         utterances_df = pd.read_csv(self.local_path + "utterances_df.csv")
 
-        utterances_df["tokens"] = utterances_df.loc[:, "text"].astype(str).apply(
-            self.spacy_apply
+        utterances_df["tokens"] = (
+            utterances_df.loc[:, "text"].astype(str).apply(self.spacy_apply)
         )
         utterances_df.to_csv(self.local_path + "utterances_df.csv", index=False)
         print("Spacy tokenization complete.")

--- a/supreme_court_predictions/statistics/tokenizer.py
+++ b/supreme_court_predictions/statistics/tokenizer.py
@@ -59,7 +59,7 @@ class Tokenizer:
         """
         utterances_df = pd.read_csv(self.local_path + "utterances_df.csv")
 
-        utterances_df["tokens"] = utterances_df.loc[:, "text"].apply(
+        utterances_df["tokens"] = utterances_df.loc[:, "text"].astype(str).apply(
             self.spacy_apply
         )
         utterances_df.to_csv(self.local_path + "utterances_df.csv", index=False)


### PR DESCRIPTION
## Describe your changes
This version still works for the shorter csv file as merged before. 

This version takes care of None types and empty strings by changing them to strings. 

For the 400 MB utterance.csv, the run time is pretty long, and the 5-year Roberts case dataset might help shorten the runtime. If you would like to check if this works for all data, sending a data job to Hadoop/GCP might be worthwile. 

## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] The code runs successfully.
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
- [x] The `Lint` GitHub Action step is passing.
  - Manually run `make format` to correct the errors.
