### PR TITLE
Address Poetry error

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,3 @@
 Here is some console output
 ```
 - [ ] I ran `make lint` and have made the bulk of changes that it has requested.
-- [ ] The `Lint` GitHub Action step is passing.
-  - Manually run `make format` to correct the errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = "The capstone project for the CAPP 30254 course at the University of Chicago."
 authors = ["michplunkett", "chanteriam", "FedericoDM", "JJModern"]
 readme = "README.md"
-packages = [{include = "poetry_python_project"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Describe your changes
Addressed error with the `pyproject.toml` file that was causing this response after the `poetry install` command was entered:
```
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % poetry install
Installing dependencies from lock file

No dependencies to install or update

/Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme-court-predictions does not contain any element
```

## Checklist before requesting a review
- [x] The code runs successfully.

```
michaelp@MacBook-Air-3 supreme-court-ml-predictions % poetry shell
Spawning shell within /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/.venv
Restored session: Sat Apr 29 19:02:07 CDT 2023
michaelp@MacBook-Air-3 supreme-court-ml-predictions % emulate bash -c '. /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/.venv/bin/activate'
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % poetry install
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: supreme-court-predictions (0.1.0)
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % 
```
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
