### PR TITLE
Cleaning Improved, Spacy Lemmatized, Stop Words Eliminated, Edge Cases & Typos Removed

### DIFF
--- a/supreme_court_predictions/statistics/datacleaner.py
+++ b/supreme_court_predictions/statistics/datacleaner.py
@@ -187,10 +187,9 @@ class DataCleaner:
                 "id": utterance["id"],
             }
             utterance_text = utterance["text"]
-            # TODO: More robust cleaning
             clean_utterance = utterance_text.lower()
             no_newline = re.sub(r"[\r\n\t]", " ", clean_utterance)
-            no_bracket = re.sub(r"[\[\]\(\)-]", "", no_newline)
+            no_bracket = re.sub(r"[\[\]\(\)]", "", no_newline)
 
             clean_dict["text"] = no_bracket
 

--- a/supreme_court_predictions/statistics/tokenizer.py
+++ b/supreme_court_predictions/statistics/tokenizer.py
@@ -50,7 +50,7 @@ class Tokenizer:
         :return: List of tokenized words.
         """
         doc = self.nlp(text)
-        return [token.text for token in doc]
+        return [token.lemma_ for token in doc if token.is_alpha and not token.is_stop]
 
     def tokenize(self):
         """

--- a/supreme_court_predictions/statistics/tokenizer.py
+++ b/supreme_court_predictions/statistics/tokenizer.py
@@ -50,7 +50,11 @@ class Tokenizer:
         :return: List of tokenized words.
         """
         doc = self.nlp(text)
-        return [token.lemma_ for token in doc if token.is_alpha and not token.is_stop]
+        return [
+            token.lemma_
+            for token in doc
+            if token.is_alpha and not token.is_stop
+        ]
 
     def tokenize(self):
         """


### PR DESCRIPTION
## Describe your changes
Cleaning Improved, Spacy Lemmatized, Stop Words Eliminated, Edge Cases & Typos Removed.

1. Words are now lemmatized to base words. 

2. Stop words such as "a" or "the" are removed.

3. Avoids cleaning errors such as "threemonth"

Cases such as " --" these are now not taken out in datacleaner but rather in tokenizer. This avoids errors such as "threemonth".

4. This version also takes out punctuation marks that were considered separate words in previous spacy tokenization.

5. This version also handles typos from original text. This is one error "violated.sentences" that seems to be a typo from the original data. The improved Spacy intake handles this case by excluding words that have any punctuation in between.


## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] The code runs successfully.
- [x] I ran `make lint` and have made the bulk of changes that it has requested.

```
oh, what up?
Data will be saved to: 
/base_directory/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Spacy module successfully loaded.
Spacy tokenization complete.
```

CSV example file:

```
case_id,speaker,speaker_type,conversation_id,id,text,tokens
1955_71,j__earl_warren,J,13127,13127__0_000,"number 71, lonnie affronti versus united states of america. mr. murphy.","['number', 'lonnie', 'affronti', 'versus', 'united', 'states', 'america', 'mr', 'murphy']"
1955_71,harry_f_murphy,A,13127,13127__0_001,"may it please the court. we are here by writ of certiorari to the eighth circuit. there is one question to be decided in this case, decided carefully. upon sentence to consecutive sentences or terms by a district court. the defending pattern started the service of a first sentence. thus, the district court thereafter have jurisdiction to suspend the execution of the remaining sentences and place the defendant on probation.","['court', 'writ', 'certiorari', 'eighth', 'circuit', 'question', 'decide', 'case', 'decide', 'carefully', 'sentence', 'consecutive', 'sentence', 'term', 'district', 'court', 'defend', 'pattern', 'start', 'service', 'sentence', 'district', 'court', 'jurisdiction', 'suspend', 'execution', 'remain', 'sentence', 'place', 'defendant', 'probation']"
1955_71,j__william_o_douglas,J,13127,13127__0_002,consecutive sentences.,"['consecutive', 'sentence']"
1955_71,harry_f_murphy,A,13127,13127__0_003,"consecutive sentences. in this case, the defendant, affronti, was indicted in 1932 by a grand jury in the western district of missouri. charged in an indictment in ten counts with the illegal sale of narcotics. i've mentioned the dates because they, if not of importance, will be of interest. in 1944, the defendant was brought in to the district court at kansas city on a writ of habeas corpus ad prosequendum from the missouri state penitentiary where he was in the service of a sentence for second degree murder. the district judge on that -- at that time was judge caskie collet. upon trial before a jury, the defendant was acquitted on the first of the ten counts, found guilty on the remaining nine and sentence was pronounced disclosed. on all nine counts of the -- the indictment, he was sentenced to serve five years which was the maximum sentence under the statute that had been violated.sentences two, three, four and five were pronounced to run consecutively. the remaining five sentences, sentence was suspended and the defendant was to be placed upon probation for a period of 25 years. the judgment further provided that the sentence on the second count would be to commence at the time he was released from authorities in missouri state. in 1949, after his release from the missouri state penitentiary, he was delivered to the united states marshal for the service of the first five years of the second count of the indictment. in 1953, four years later --","['consecutive', 'sentence', 'case', 'defendant', 'affronti', 'indict', 'grand', 'jury', 'western', 'district', 'missouri', 'charge', 'indictment', 'count', 'illegal', 'sale', 'narcotic', 'mention', 'date', 'importance', 'interest', 'defendant', 'bring', 'district', 'court', 'kansas', 'city', 'writ', 'habeas', 'corpus', 'ad', 'prosequendum', 'missouri', 'state', 'penitentiary', 'service', 'sentence', 'second', 'degree', 'murder', 'district', 'judge', 'time', 'judge', 'caskie', 'collet', 'trial', 'jury', 'defendant', 'acquit', 'count', 'find', 'guilty', 'remain', 'sentence', 'pronounce', 'disclose', 'count', 'indictment', 'sentence', 'serve', 'year', 'maximum', 'sentence', 'statute', 'pronounce', 'run', 'consecutively', 'remain', 'sentence', 'sentence', 'suspend', 'defendant', 'place', 'probation', 'period', 'year', 'judgment', 'provide', 'sentence', 'second', 'count', 'commence', 'time', 'release', 'authority', 'missouri', 'state', 'release', 'missouri', 'state', 'penitentiary', 'deliver', 'united', 'states', 'marshal', 'service', 'year', 'second', 'count', 'indictment', 'year', 'later']"
1955_71,<INAUDIBLE>,,13127,13127__0_004,was the aggregate prison sentence was 20 or 25 years?,"['aggregate', 'prison', 'sentence', 'year']"
1955_71,harry_f_murphy,A,13127,13127__0_005,twenty years.,['year']
1955_71,<INAUDIBLE>,,13127,13127__0_006,twenty years.,['year']
1955_71,harry_f_murphy,A,13127,13127__0_007,"twenty years, four -- four counts of five years. but the computation is a question whether he had yet started the service as -- as second of his third five years, but in 1943, at which time judge duncan had succeeded judge collet as the district judge in that division, judge collet having been promoted to the eighth circuit bench. a motion was filed on his behalf requesting that the remaining sentences yet to be served, either the third, fourth, and fifth counts or the fourth and fifth, that the execution of the sentence as yet to be served be suspended and be placed on probation. now, in -- two months prior to the filing of the motion on behalf of the petitioner in the district court, judge reeves, another division of the western district had ruled in the case of phillips versus the united states for the facts as far as sentences are concerned, were identical with the facts in this case, and that phillips, the defendant, was in the service of the first of three consecutive terms. that the court was without jurisdiction to entertain such a motion as the term had passed and the 60 days had -- had passed when he had -- after he had been first sentenced. pending the appeal of the phillips case, judge duncan held in abeyance of ruling on the affronti case. on appeal to the united states court of appeals for the eighth circuit, the phillips decision was affirmed. on that bench, sitting as a member of the court of appeals, was judge collet. and in a dissenting opinion, he held that a district court in his opinion had a right to retain jurisdiction over sentences yet to be served. after the phillips case was passed, the time had passed, no application was made to this court for certiorari, although the court of appeals had recommended that he'd be permitted to apply without the payment of cost. the court -- appeal was taken in the affronti case to the same court. and again, on that same court, judge collet sat as a member of the court of appeals. following the phillips case, the court of appeals affirmed the phillips case. judge collet consistently again dissenting. again, that court recommended that affronti be permitted to apply for certiorari without the payment of costs. the basis of the ruling in the phillips case, opinion by judge reeves, the district judge and followed up by the court of appeals, was an early case passed on this court in 1948 by the opinion written by chief justice taft, murray versus the united states, in which the facts briefly were these. a man by the name of cook had been sentenced in a texas district court for a total of 14 years and some months. a man in nebraska had been sentenced to three months on six counts to run concurrently. after the defendant murray had served one day of his three-month sentence, the sentencing judge made an order suspending the execution of that sentence and placed murray on probation for the balance of his term. shortly thereafter in texas, the district court in the cook case, after the service of sentence had been began by cook for several years at least, on the one sentence according to the opinion, the court in that case ordered the defendant placed on probation, suspended the execution of the remaining sentence then being served. upon appeal by the government to this court, certiorari from the eighth circuit and the fifth, i believe it was, the opinion held that having once -- once started the service of the sentence, the district court was without power to place the defendant on probation suspend the execution of that sentence. in that case, there was no question of consecutive sentences, although perhaps, in the cook case, the sentence actually was of sentences running consecutively. but that doesn't appear to have been of any moment at least to the court in the murray opinion. that created, if not confusion, at least some difference of opinions in the different circuits as to the right of the sentencing judge under the probation act to sentence and suspend at the same time. some courts holding that having sentenced on one count, the court could not, on remaining counts, place the -- the defendant on probation. that had been followed or there was some confusion in the various circuits or the districts, shall we say, until the kirk case went up to the ninth circuit from california. in that case, three defendants had been sentenced on consecutive terms, the first two of which were seventeen and a half years and the third for two years. during the service of the first sentence by one of the defendants, the court in that case ordered the execution, suspend the remaining sentences, and at the completion of the service of that first sentence, the defendant was to be placed on probation.","['year', 'count', 'year', 'computation', 'question', 'start', 'service', 'second', 'year', 'time', 'judge', 'duncan', 'succeed', 'judge', 'collet', 'district', 'judge', 'division', 'judge', 'collet', 'have', 'promote', 'eighth', 'circuit', 'bench', 'motion', 'file', 'behalf', 'request', 'remain', 'sentence', 'serve', 'fourth', 'fifth', 'count', 'fourth', 'fifth', 'execution', 'sentence', 'serve', 'suspend', 'place', 'probation', 'month', 'prior', 'filing', 'motion', 'behalf', 'petitioner', 'district', 'court', 'judge', 'reeve', 'division', 'western', 'district', 'rule', 'case', 'phillip', 'versus', 'united', 'states', 'fact', 'far', 'sentence', 'concern', 'identical', 'fact', 'case', 'phillip', 'defendant', 'service', 'consecutive', 'term', 'court', 'jurisdiction', 'entertain', 'motion', 'term', 'pass', 'day', 'pass', 'sentence', 'pende', 'appeal', 'phillip', 'case', 'judge', 'duncan', 'hold', 'abeyance', 'rule', 'affronti', 'case', 'appeal', 'united', 'states', 'court', 'appeal', 'eighth', 'circuit', 'phillip', 'decision', 'affirm', 'bench', 'sit', 'member', 'court', 'appeal', 'judge', 'collet', 'dissent', 'opinion', 'hold', 'district', 'court', 'opinion', 'right', 'retain', 'jurisdiction', 'sentence', 'serve', 'phillip', 'case', 'pass', 'time', 'pass', 'application', 'court', 'certiorari', 'court', 'appeal', 'recommend', 'permit', 'apply', 'payment', 'cost', 'court', 'appeal', 'take', 'affronti', 'case', 'court', 'court', 'judge', 'collet', 'sit', 'member', 'court', 'appeal', 'follow', 'phillip', 'case', 'court', 'appeal', 'affirm', 'phillip', 'case', 'judge', 'collet', 'consistently', 'dissent', 'court', 'recommend', 'affronti', 'permit', 'apply', 'certiorari', 'payment', 'cost', 'basis', 'ruling', 'phillip', 'case', 'opinion', 'judge', 'reeve', 'district', 'judge', 'follow', 'court', 'appeal', 'early', 'case', 'pass', 'court', 'opinion', 'write', 'chief', 'justice', 'taft', 'murray', 'versus', 'united', 'states', 'fact', 'briefly', 'man', 'cook', 'sentence', 'texas', 'district', 'court', 'total', 'year', 'month', 'man', 'nebraska', 'sentence', 'month', 'count', 'run', 'concurrently', 'defendant', 'murray', 'serve', 'day', 'month', 'sentence', 'sentencing', 'judge', 'order', 'suspend', 'execution', 'sentence', 'place', 'murray', 'probation', 'balance', 'term', 'shortly', 'texas', 'district', 'court', 'cook', 'case', 'service', 'sentence', 'begin', 'cook', 'year', 'sentence', 'accord', 'opinion', 'court', 'case', 'order', 'defendant', 'place', 'probation', 'suspend', 'execution', 'remain', 'sentence', 'serve', 'appeal', 'government', 'court', 'certiorari', 'eighth', 'circuit', 'fifth', 'believe', 'opinion', 'hold', 'have', 'start', 'service', 'sentence', 'district', 'court', 'power', 'place', 'defendant', 'probation', 'suspend', 'execution', 'sentence', 'case', 'question', 'consecutive', 'sentence', 'cook', 'case', 'sentence', 'actually', 'sentence', 'run', 'consecutively', 'appear', 'moment', 'court', 'murray', 'opinion', 'create', 'confusion', 'difference', 'opinion', 'different', 'circuit', 'right', 'sentencing', 'judge', 'probation', 'act', 'sentence', 'suspend', 'time', 'court', 'hold', 'have', 'sentence', 'count', 'court', 'remain', 'count', 'place', 'defendant', 'probation', 'follow', 'confusion', 'circuit', 'district', 'shall', 'kirk', 'case', 'go', 'ninth', 'circuit', 'california', 'case', 'defendant', 'sentence', 'consecutive', 'term', 'seventeen', 'half', 'year', 'year', 'service', 'sentence', 'defendant', 'court', 'case', 'order', 'execution', 'suspend', 'remain', 'sentence', 'completion', 'service', 'sentence', 'defendant', 'place', 'probation']"

```

