### PR TITLE
Add additional data cleaning based on checkpoint 1 feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,7 @@ clean-data:
 .PHONY: describe-data
 describe-data:
 	python -m ${BASEDIR} --describe-data
+
+.PHONY: tokenize-data
+tokenize-data:
+	python -m ${BASEDIR} --tokenize-data

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test-and-fail:
 
 .PHONY: run
 run:
-	python -m ${BASEDIR} --get-data --clean-data --describe-data
+	python -m ${BASEDIR} --get-data --clean-data --describe-data --tokenize-data
 
 .PHONY: get-data
 get-data:

--- a/supreme_court_predictions/__main__.py
+++ b/supreme_court_predictions/__main__.py
@@ -8,6 +8,7 @@ from supreme_court_predictions.api.convokit.client import get_data
 from supreme_court_predictions.statistics.service import (
     clean_data,
     describe_data,
+    tokenize_data,
 )
 
 if __name__ == "__main__":
@@ -39,6 +40,14 @@ if __name__ == "__main__":
         action=argparse.BooleanOptionalAction,
     )
 
+    parser.add_argument(
+        "--tokenize-data",
+        help="Generate tokenizations for Convokit",
+        type=bool,
+        default=False,
+        action=argparse.BooleanOptionalAction,
+    )
+
     args = parser.parse_args()
 
     if args.get_data:
@@ -49,3 +58,6 @@ if __name__ == "__main__":
 
     if args.describe_data:
         describe_data()
+
+    if args.tokenize_data:
+        tokenize_data()

--- a/supreme_court_predictions/__main__.py
+++ b/supreme_court_predictions/__main__.py
@@ -33,16 +33,16 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--describe-data",
-        help="Generate descriptive statistics for Convokit",
+        "--tokenize-data",
+        help="Generate tokenizations for Convokit",
         type=bool,
         default=False,
         action=argparse.BooleanOptionalAction,
     )
 
     parser.add_argument(
-        "--tokenize-data",
-        help="Generate tokenizations for Convokit",
+        "--describe-data",
+        help="Generate descriptive statistics for Convokit",
         type=bool,
         default=False,
         action=argparse.BooleanOptionalAction,
@@ -56,8 +56,8 @@ if __name__ == "__main__":
     if args.clean_data:
         clean_data()
 
-    if args.describe_data:
-        describe_data()
-
     if args.tokenize_data:
         tokenize_data()
+
+    if args.describe_data:
+        describe_data()

--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -245,7 +245,12 @@ class Descriptives:
 
     def votes_by_justice(self, voters):
         """
-        Calculates the proportion of votes in favor of the petitioner by justice.
+        Calculates the proportion of votes in favor of the petitioner by 
+        justice.
+
+        :param voters: Dataframe including voter information.
+        :return Dataframe of descriptive statistics for votes by SCOTUS 
+                justices.
         """
 
         # Get justices

--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -102,8 +102,6 @@ class Descriptives:
         sides = [
             "for petitioner",
             "for respondent",
-            "unknown",
-            "for amicus curiae",
         ]
 
         advocate_stats.index = self.fix_indices("side", sides)
@@ -139,7 +137,6 @@ class Descriptives:
             "inferred": 0,
             "for respondent": 0,
             "for petitioner": 0,
-            "for amicus curiae": 0,
         }
         for role in roles:
             if "inferred" in role:
@@ -151,10 +148,6 @@ class Descriptives:
             elif "petitioner" in role or "appellant" in role:
                 clean_roles["for petitioner"] = (
                     clean_roles.get("for petitioner") + 1
-                )
-            elif "amicus curiae" in role:
-                clean_roles["for amicus curiae"] = (
-                    clean_roles.get("for amicus curiae") + 1
                 )
             else:
                 clean_roles[role] = clean_roles.get(role, 0) + 1
@@ -187,7 +180,7 @@ class Descriptives:
         # Get descriptive stats
         speakers_stats = self.get_count_desc(speakers, ["speaker_type"])
 
-        speaker_types = ["advocate (A)", "justice (J)", "unknown (U)"]
+        speaker_types = ["advocate (A)", "justice (J)"]
         speakers_stats.index = self.fix_indices("speaker type", speaker_types)
 
         # Add count of unique speaker names and keys
@@ -239,14 +232,41 @@ class Descriptives:
 
         # Get descriptive stats of votes
         voter_stats = self.get_count_desc(voters, ["vote"])
-        vote_types = ["for petitioner", "for respondent", "unknown"]
+        vote_types = ["for petitioner", "for respondent"]
         voter_stats.index = self.fix_indices("votes", vote_types)
 
         voter_stats.loc[("justices", ""), "counts"] = len(
             voters.loc[:, "voter"].unique()
         )
 
+        voter_stats = pd.concat([voter_stats, self.votes_by_justice(voters)])
+
         return voter_stats
+
+    def votes_by_justice(self, voters):
+        """
+        Calculates the proportion of votes in favor of the petitioner by justice.
+        """
+
+        # Get justices
+        justices = voters.loc[:, "voter"].unique()
+        indices = self.fix_indices("justice", justices)
+        voters_df = pd.DataFrame(
+            index=indices, columns=["counts", "percentages"]
+        )
+
+        for justice in justices:
+            # get counts
+            voters_df.loc[("justice", justice), "counts"] = len(
+                voters.loc[voters.loc[:, "voter"] == justice, :]
+            )
+
+            # get percent for petitioner
+            voters_df.loc[("justice", justice), "percentages"] = voters.loc[
+                voters.loc[:, "voter"] == justice, "vote"
+            ].sum() / len(voters.loc[voters.loc[:, "voter"] == justice, :])
+
+        return voters_df
 
     def get_cases_desc(self):
         """
@@ -261,8 +281,6 @@ class Descriptives:
         winning_sides = [
             "for petitioner",
             "for respondent",
-            "unclear",
-            "unavailable",
         ]
 
         cases_stats = self.get_count_desc(cases, ["win_side"])
@@ -296,12 +314,11 @@ class Descriptives:
         Calculates descriptive statistics for all of the supreme corpus
         DataFrames and exports them to csv/excel (if applicable).
         """
+        print("Grabbing case descriptive statistics...")
+        self.cases_stats = self.get_cases_desc()
 
         print("Grabbing advocates descriptive statistics...")
         self.advocates_stats = self.get_advocate_desc()
-
-        print("Grabbing case descriptive statistics...")
-        self.cases_stats = self.get_cases_desc()
 
         print("Grabbing speakers descriptive statistics...")
         self.speakers_stats = self.get_speaker_desc()

--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -245,11 +245,11 @@ class Descriptives:
 
     def votes_by_justice(self, voters):
         """
-        Calculates the proportion of votes in favor of the petitioner by 
+        Calculates the proportion of votes in favor of the petitioner by
         justice.
 
         :param voters: Dataframe including voter information.
-        :return Dataframe of descriptive statistics for votes by SCOTUS 
+        :return Dataframe of descriptive statistics for votes by SCOTUS
                 justices.
         """
 

--- a/supreme_court_predictions/statistics/service.py
+++ b/supreme_court_predictions/statistics/service.py
@@ -9,8 +9,11 @@ from supreme_court_predictions.statistics.tokenizer import Tokenizer
 
 def clean_data():
     DataCleaner(downloaded_corpus=True, save_data=True).parse_all_data()
-    Tokenizer()
 
 
 def describe_data():
     Descriptives(downloaded_clean_corpus=True, save_data=True).parse_all_data()
+
+
+def tokenize_data():
+    Tokenizer()

--- a/supreme_court_predictions/util/contants.py
+++ b/supreme_court_predictions/util/contants.py
@@ -7,3 +7,6 @@ ENCODING_UTF_8 = "utf-8"
 # File modes
 FILE_MODE_READ = "r"
 FILE_MODE_WRITE = "w"
+
+# Current year for data filterning
+LATEST_YEAR = 2019


### PR DESCRIPTION
## Describe your changes
I cleaned and filtered the corpus data based on the following criteria (in datacleaner.py):
- only included cases from 2014-2019 (the latest year of the dataset)
- only included cases where the winning side was either 0 or 1 (no missing, etc.)
- filtered the speakers, conversations, utterances, voters, and advocates dataframes based on the case_ids returned from the above cleaning and filtering

In descriptives.py, I edited the file based on the new dataframes returned above and also included more descriptive statistics based on the voting habits of particular justices.

Finally, I added a make command for tokenization.

## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] The code runs successfully.
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
