### PR TITLE
Added `debug_mode` flag to application

### DIFF
--- a/supreme_court_predictions/__main__.py
+++ b/supreme_court_predictions/__main__.py
@@ -90,26 +90,42 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Debug mode will only trigger when we call functionality from the command
+    # line, which means we shouldn't get an obscene amount of printouts
+    # in our Jupyter notebooks.
+    debug_mode = any(
+        [
+            args.get_data,
+            args.clean_data,
+            args.tokenize_data,
+            args.describe_data,
+            args.process_data,
+            args.logistic_regression,
+            args.random_forest,
+            args.xg_boost,
+        ]
+    )
+
     if args.get_data:
-        get_data()
+        get_data(debug_mode)
 
     if args.clean_data:
-        clean_data()
+        clean_data(debug_mode)
 
     if args.tokenize_data:
-        tokenize_data()
+        tokenize_data(debug_mode)
 
     if args.describe_data:
-        describe_data()
+        describe_data(debug_mode)
 
     if args.process_data:
-        process_data()
+        process_data(debug_mode)
 
     if args.logistic_regression:
-        run_linear_regression()
+        run_linear_regression(debug_mode)
 
     if args.random_forest:
-        run_random_forest()
+        run_random_forest(debug_mode)
 
     if args.xg_boost:
-        run_xg_boost()
+        run_xg_boost(debug_mode)

--- a/supreme_court_predictions/__main__.py
+++ b/supreme_court_predictions/__main__.py
@@ -11,13 +11,11 @@ from supreme_court_predictions.models.service import (
     run_xg_boost,
 )
 from supreme_court_predictions.processing.service import (
+    clean_data,
     process_data,
     tokenize_data,
 )
-from supreme_court_predictions.statistics.service import (
-    clean_data,
-    describe_data,
-)
+from supreme_court_predictions.statistics.service import describe_data
 
 if __name__ == "__main__":
     print("oh, what up?")

--- a/supreme_court_predictions/api/convokit.py
+++ b/supreme_court_predictions/api/convokit.py
@@ -14,14 +14,17 @@ from supreme_court_predictions.util.functions import (
 )
 
 
-def get_data(debug=True):
+def get_data(debug_mode=False):
     """
     Loads and outputs the Supreme Court Corpus and case verdict data
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
     """
 
     convokit_path = get_full_data_pathway("convokit/")
 
-    debug_print("Loading Supreme Court Corpus Data...", debug)
+    debug_print("Loading Supreme Court Corpus Data...", debug_mode)
     corpus = Corpus(filename=download("supreme-corpus"))
     corpus.dump("supreme_corpus", base_path=convokit_path)
 

--- a/supreme_court_predictions/models/logistic_regression.py
+++ b/supreme_court_predictions/models/logistic_regression.py
@@ -14,10 +14,7 @@ from sklearn.model_selection import train_test_split
 
 from supreme_court_predictions.models.model import Model
 from supreme_court_predictions.util.contants import SEED_CONSTANT
-from supreme_court_predictions.util.functions import (
-    debug_print,
-    get_full_data_pathway,
-)
+from supreme_court_predictions.util.functions import get_full_data_pathway
 
 
 class LogisticRegression(Model):
@@ -28,6 +25,7 @@ class LogisticRegression(Model):
 
     def __init__(
         self,
+        debug_mode=False,
         dfs=[
             "case_aggregations.p",
             "judge_aggregations.p",
@@ -37,15 +35,14 @@ class LogisticRegression(Model):
         max_features=5000,
         test_size=0.20,
         max_iter=1000,
-        print_results=True,
     ):
+        self.accuracies = []
+        self.debug_mode = debug_mode
         self.local_path = get_full_data_pathway("processed/")
         self.max_features = max_features
-        self.test_size = test_size
         self.max_iter = max_iter
-        self.print = print_results
         self.name = "Regression"
-        self.accuracies = []
+        self.test_size = test_size
 
         # Dataframes and df names to run models against
         self.dataframes = []
@@ -73,7 +70,7 @@ class LogisticRegression(Model):
         :return (regressor, y_test, y_pred): A tuple that contains the
         regression model, test y-data, the predicted y-data.
         """
-        debug_print("Creating bag of words", self.print)
+        self.print("Creating bag of words")
         vectorizer = CountVectorizer(
             analyzer="word", max_features=self.max_features
         )
@@ -90,7 +87,7 @@ class LogisticRegression(Model):
             stratify=bag_of_words_y,
         )
 
-        debug_print("Starting the Logistic Regression", self.print)
+        self.print("Starting the Logistic Regression")
         regressor = skLR(max_iter=self.max_iter)
 
         # Fit the classifier on the training data
@@ -112,16 +109,11 @@ class LogisticRegression(Model):
                 # Print the results, if applicable
                 self.print_results(self.name.lower(), acc, df_name)
             except ValueError:
-                debug_print(
-                    "------------------------------------------", self.print
+                self.print("------------------------------------------")
+                self.print(
+                    "Error: training data is not big enough for this subset"
                 )
-                debug_print(
-                    "Error: training data is not big enough for this subset",
-                    self.print,
-                )
-                debug_print(
-                    "------------------------------------------", self.print
-                )
+                self.print("------------------------------------------")
 
         return self.accuracies
 

--- a/supreme_court_predictions/models/logistic_regression.py
+++ b/supreme_court_predictions/models/logistic_regression.py
@@ -119,7 +119,7 @@ class LogisticRegression(Model):
 
     def __repr__(self):
         """
-        Overwrites default string representation of Model
+        Overwrites default string representation of Model.
 
         :return string representation of Model
         """

--- a/supreme_court_predictions/models/model.py
+++ b/supreme_court_predictions/models/model.py
@@ -51,7 +51,7 @@ class Model(ABC):
     @abstractmethod
     def __repr__(self):
         """
-        Overwrites default string representation
+        Overwrites default string representation.
         """
 
     def print_results(
@@ -62,9 +62,9 @@ class Model(ABC):
 
         :param str model_name: The name of the model.
         :param list accuracy_score: The accuracy scores generated across for
-        the dataframes ran in the model.
+            the dataframes ran in the model.
         :param list dataframe_name: Name of the dataframe used to create the
-        model.
+            model.
         """
         if self.debug_mode:
             print("------------------------------------------")

--- a/supreme_court_predictions/models/model.py
+++ b/supreme_court_predictions/models/model.py
@@ -38,6 +38,16 @@ class Model(ABC):
         Runs the model on its respective data.
         """
 
+    def print(self, message: str):
+        """
+        Handles the decision to print a message to standard out, and does so
+        if the application is in debug mode.
+
+        :param message: The message to be printed.
+        """
+        if self.debug_mode:
+            print(message)
+
     @abstractmethod
     def __repr__(self):
         """
@@ -56,7 +66,7 @@ class Model(ABC):
         :param list dataframe_name: Name of the dataframe used to create the
         model.
         """
-        if self.print:
+        if self.debug_mode:
             print("------------------------------------------")
             print(f"Running a {model_name} on {dataframe_name}...")
             print(f"Accuracy score: {accuracy_score}")

--- a/supreme_court_predictions/models/model.py
+++ b/supreme_court_predictions/models/model.py
@@ -4,6 +4,8 @@ This file contains the class that is the basis for all models in this package.
 
 from abc import ABC, abstractmethod
 
+from supreme_court_predictions.util.functions import debug_print
+
 
 class Model(ABC):
     """
@@ -45,8 +47,7 @@ class Model(ABC):
 
         :param message: The message to be printed.
         """
-        if self.debug_mode:
-            print(message)
+        debug_print(message, self.debug_mode)
 
     @abstractmethod
     def __repr__(self):

--- a/supreme_court_predictions/models/random_forest.py
+++ b/supreme_court_predictions/models/random_forest.py
@@ -8,10 +8,7 @@ from sklearn.model_selection import train_test_split
 
 from supreme_court_predictions.models.model import Model
 from supreme_court_predictions.util.contants import SEED_CONSTANT
-from supreme_court_predictions.util.functions import (
-    debug_print,
-    get_full_data_pathway,
-)
+from supreme_court_predictions.util.functions import get_full_data_pathway
 
 
 class RandomForest(Model):
@@ -22,6 +19,7 @@ class RandomForest(Model):
 
     def __init__(
         self,
+        debug_mode=False,
         dfs=[
             "case_aggregations.p",
             "judge_aggregations.p",
@@ -34,14 +32,14 @@ class RandomForest(Model):
         max_depth=None,
         print_results=True,
     ):
-        self.local_path = get_full_data_pathway("processed/")
-        self.max_features = max_features
-        self.test_size = test_size
-        self.num_trees = num_trees
-        self.max_depth = max_depth
-        self.print = print_results
-        self.name = "Random Forest"
         self.accuracies = []
+        self.debug_mode = debug_mode
+        self.local_path = get_full_data_pathway("processed/")
+        self.max_depth = max_depth
+        self.max_features = max_features
+        self.name = "Random Forest"
+        self.num_trees = num_trees
+        self.test_size = test_size
 
         # Dataframes and df names to run models against
         self.dataframes = []
@@ -69,7 +67,7 @@ class RandomForest(Model):
         :return (forest, y_test, y_pred): A tuple that contains the
         forest model, test y-data, the predicted y-data.
         """
-        debug_print("Creating bag of words", self.print)
+        self.print("Creating bag of words")
         vectorizer = CountVectorizer(
             analyzer="word", max_features=self.max_features
         )
@@ -86,8 +84,7 @@ class RandomForest(Model):
             stratify=bag_of_words_y,
         )
 
-        if self.print:
-            debug_print("Starting the Random Forest", self.print)
+        self.print("Starting the Random Forest")
         forest = RandomForestClassifier(
             n_estimators=self.num_trees, max_depth=self.max_depth
         )
@@ -111,16 +108,11 @@ class RandomForest(Model):
                 # Print the results, if applicable
                 self.print_results(self.name.lower(), acc, df_name)
             except ValueError:
-                debug_print(
-                    "------------------------------------------", self.print
+                self.print("------------------------------------------")
+                self.print(
+                    "Error: training data is not big enough for this " "subset"
                 )
-                debug_print(
-                    "Error: training data is not big enough for this " "subset",
-                    self.print,
-                )
-                debug_print(
-                    "------------------------------------------", self.print
-                )
+                self.print("------------------------------------------")
 
         return self.accuracies
 

--- a/supreme_court_predictions/models/random_forest.py
+++ b/supreme_court_predictions/models/random_forest.py
@@ -118,7 +118,7 @@ class RandomForest(Model):
 
     def __repr__(self):
         """
-        Overwrites default string representation of Model
+        Overwrites default string representation of Model.
 
         :return string representation of Model
         """

--- a/supreme_court_predictions/models/service.py
+++ b/supreme_court_predictions/models/service.py
@@ -9,13 +9,31 @@ from supreme_court_predictions.models.random_forest import RandomForest
 from supreme_court_predictions.models.xg_boost import XGBoost
 
 
-def run_linear_regression():
-    LogisticRegression().run()
+def run_linear_regression(debug_mode=False):
+    """
+    Runner function for the Linear Regression model.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    LogisticRegression(debug_mode=debug_mode).run()
 
 
-def run_random_forest():
-    RandomForest().run()
+def run_random_forest(debug_mode=False):
+    """
+    Runner function for the Random Forest model.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    RandomForest(debug_mode=debug_mode).run()
 
 
-def run_xg_boost():
-    XGBoost().run()
+def run_xg_boost(debug_mode=False):
+    """
+    Runner function for the XG Boost model.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    XGBoost(debug_mode=debug_mode).run()

--- a/supreme_court_predictions/models/xg_boost.py
+++ b/supreme_court_predictions/models/xg_boost.py
@@ -123,7 +123,7 @@ class XGBoost(Model):
 
     def __repr__(self):
         """
-        Overwrites default string representation of Model
+        Overwrites default string representation of Model.
 
         :return string representation of Model
         """

--- a/supreme_court_predictions/models/xg_boost.py
+++ b/supreme_court_predictions/models/xg_boost.py
@@ -14,10 +14,7 @@ from sklearn.model_selection import train_test_split
 
 from supreme_court_predictions.models.model import Model
 from supreme_court_predictions.util.contants import SEED_CONSTANT
-from supreme_court_predictions.util.functions import (
-    debug_print,
-    get_full_data_pathway,
-)
+from supreme_court_predictions.util.functions import get_full_data_pathway
 
 # from sklearn.model_selection import cross_val_score
 # from sklearn.metrics import confusion_matrix
@@ -32,18 +29,18 @@ class XGBoost(Model):
 
     def __init__(
         self,
+        debug_mode=False,
         dfs=[
             "case_aggregations.p",
             "judge_aggregations.p",
             "advocate_aggregations.p",
             "adversary_aggregations.p",
         ],
-        print_results=True,
     ):
-        self.local_path = get_full_data_pathway("processed/")
-        self.print = print_results
-        self.name = "Gradient Boosted Tree Model"
         self.accuracies = []
+        self.debug_mode = debug_mode
+        self.local_path = get_full_data_pathway("processed/")
+        self.name = "Gradient Boosted Tree Model"
 
         # Dataframes and df names to run models against
         self.dataframes = []
@@ -71,7 +68,7 @@ class XGBoost(Model):
         :return (regressor, y_test, y_pred): A tuple that contains the
         regression model, test y-data, the predicted y-data.
         """
-        debug_print("Creating bag of words", self.print)
+        self.print("Creating bag of words")
 
         vectorizer = CountVectorizer(analyzer="word", max_features=5000)
         vectorize_document = df.loc[:, "tokens"].apply(" ".join)
@@ -86,7 +83,7 @@ class XGBoost(Model):
             stratify=bag_of_words_y,
         )
 
-        debug_print("Starting the XGBoost model", self.print)
+        self.print("Starting the XGBoost model")
 
         xgb_model = xgb.XGBClassifier(
             max_depth=7,
@@ -108,24 +105,19 @@ class XGBoost(Model):
         Runs the create function on each type of aggregated utterance.
         """
 
-        for df, dfname in zip(self.dataframes, self.dataframe_names):
+        for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
                 acc = self.create_and_measure(df, accuracy_score)
                 self.accuracies.append(acc)
 
                 # Print the results, if applicable
-                self.print_results(self.name.lower(), acc, dfname)
+                self.print_results(self.name.lower(), acc, df_name)
             except ValueError:
-                debug_print(
-                    "------------------------------------------", self.print
+                self.print("------------------------------------------")
+                self.print(
+                    "Error: training data is not big enough for this subset"
                 )
-                debug_print(
-                    "Error: training data is not big enough for this subset",
-                    self.print,
-                )
-                debug_print(
-                    "------------------------------------------", self.print
-                )
+                self.print("------------------------------------------")
 
         return self.accuracies
 

--- a/supreme_court_predictions/processing/datacleaner.py
+++ b/supreme_court_predictions/processing/datacleaner.py
@@ -14,7 +14,10 @@ from supreme_court_predictions.util.contants import (
     FILE_MODE_READ,
     LATEST_YEAR,
 )
-from supreme_court_predictions.util.functions import debug_print, get_full_data_pathway
+from supreme_court_predictions.util.functions import (
+    debug_print,
+    get_full_data_pathway,
+)
 
 
 class DataCleaner:
@@ -34,7 +37,9 @@ class DataCleaner:
         self.utterances_df = None
 
         debug_print(f"Working in {self.local_path}", self.debug_mode)
-        debug_print(f"Data will be saved to {self.output_path}", self.debug_mode)
+        debug_print(
+            f"Data will be saved to {self.output_path}", self.debug_mode
+        )
 
     def get_data(self):
         """

--- a/supreme_court_predictions/processing/datacleaner.py
+++ b/supreme_court_predictions/processing/datacleaner.py
@@ -14,7 +14,7 @@ from supreme_court_predictions.util.contants import (
     FILE_MODE_READ,
     LATEST_YEAR,
 )
-from supreme_court_predictions.util.functions import get_full_data_pathway
+from supreme_court_predictions.util.functions import debug_print, get_full_data_pathway
 
 
 class DataCleaner:
@@ -23,27 +23,25 @@ class DataCleaner:
     it into a usable format.
     """
 
-    def __init__(self):
+    def __init__(self, debug_mode=False):
         self.cases_df = None
         self.clean_case_ids = None  # stores the case IDs to use
         self.clean_utterances_list = None
+        self.debug_mode = debug_mode
+        self.local_path = get_full_data_pathway("convokit/")
+        self.output_path = get_full_data_pathway("clean_convokit/")
         self.speakers_df = None
         self.utterances_df = None
 
-        # Get local directory
-        self.local_path = get_full_data_pathway("convokit/")
-        print(f"Working in {self.local_path}")
-
-        # Set output path
-        self.output_path = get_full_data_pathway("clean_convokit/")
-        print(f"Data will be saved to {self.output_path}")
+        debug_print(f"Working in {self.local_path}", self.debug_mode)
+        debug_print(f"Data will be saved to {self.output_path}", self.debug_mode)
 
     def get_data(self):
         """
         Loads and outputs the Supreme Court Corpus data.
         """
 
-        print("Loading Supreme Court Corpus Data...")
+        debug_print("Loading Supreme Court Corpus Data...", self.debug_mode)
         corpus = Corpus(filename=download("supreme-corpus"))
         corpus.dump("supreme_corpus", base_path=self.local_path)
 
@@ -121,8 +119,8 @@ class DataCleaner:
 
         for case in cases_lst:
             # get metadata
-            for attr, obvs in metadata.items():
-                obvs.append(case[attr])
+            for attr, observations in metadata.items():
+                observations.append(case[attr])
 
         return pd.DataFrame(metadata)
 
@@ -285,15 +283,15 @@ class DataCleaner:
         """
         Cleans and parses all the data.
         """
-        print("Parsing cases...")
+        debug_print("Parsing cases...", self.debug_mode)
         cases_list = self.load_data("cases.jsonl")
         self.cases_df = self.get_cases_df(cases_list)
 
-        print("Parsing speakers...")
+        debug_print("Parsing speakers...", self.debug_mode)
         speakers_dict = self.load_data("speakers.json")
         self.speakers_df = self.speakers_to_df(speakers_dict)
 
-        print("Parsing conversations metadata...")
+        debug_print("Parsing conversations metadata...", self.debug_mode)
         conversations_dict = self.load_data("conversations.json")
         (
             self.conversations_df,
@@ -301,7 +299,7 @@ class DataCleaner:
             self.voters_df,
         ) = self.get_conversation_dfs(conversations_dict)
 
-        print("Parsing utterances...")
+        debug_print("Parsing utterances...", self.debug_mode)
         utterances_list = self.load_data("utterances.jsonl")
         self.clean_utterances_list, self.utterances_df = self.clean_utterances(
             utterances_list
@@ -338,4 +336,4 @@ class DataCleaner:
             encoding=ENCODING_UTF_8,
         )
 
-        print("Data saved to " + self.output_path)
+        debug_print("Data saved to " + self.output_path, self.debug_mode)

--- a/supreme_court_predictions/processing/datacleaner.py
+++ b/supreme_court_predictions/processing/datacleaner.py
@@ -123,7 +123,7 @@ class DataCleaner:
         }
 
         for case in cases_lst:
-            # get metadata
+            # Get metadata
             for attr, observations in metadata.items():
                 observations.append(case[attr])
 
@@ -341,4 +341,4 @@ class DataCleaner:
             encoding=ENCODING_UTF_8,
         )
 
-        debug_print("Data saved to " + self.output_path, self.debug_mode)
+        debug_print(f"Data saved to {self.output_path}", self.debug_mode)

--- a/supreme_court_predictions/processing/service.py
+++ b/supreme_court_predictions/processing/service.py
@@ -2,10 +2,21 @@
 This file works as the central point of interaction for the processing package.
 """
 
+from supreme_court_predictions.processing.datacleaner import DataCleaner
 from supreme_court_predictions.processing.token_aggregation import (
     TokenAggregations,
 )
 from supreme_court_predictions.processing.tokenizer import Tokenizer
+
+
+def clean_data(debug_mode=False):
+    """
+    Runner function for cleaning and formatting the Convokit corpus.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    DataCleaner(debug_mode).parse_all_data()
 
 
 def tokenize_data(debug_mode=False):

--- a/supreme_court_predictions/processing/service.py
+++ b/supreme_court_predictions/processing/service.py
@@ -8,9 +8,21 @@ from supreme_court_predictions.processing.token_aggregation import (
 from supreme_court_predictions.processing.tokenizer import Tokenizer
 
 
-def tokenize_data():
-    Tokenizer()
+def tokenize_data(debug_mode=False):
+    """
+    Runner function for tokenizing data.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    Tokenizer(debug_mode)
 
 
-def process_data():
-    TokenAggregations().parse_all_data()
+def process_data(debug_mode=False):
+    """
+    Runner function for aggregating tokens.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    TokenAggregations(debug_mode).parse_all_data()

--- a/supreme_court_predictions/processing/tokenizer.py
+++ b/supreme_court_predictions/processing/tokenizer.py
@@ -8,7 +8,10 @@ tasks efficiently and effectively in a user-friendly manner.
 import pandas as pd
 import spacy
 
-from supreme_court_predictions.util.functions import get_full_data_pathway
+from supreme_court_predictions.util.functions import (
+    debug_print,
+    get_full_data_pathway,
+)
 
 
 class Tokenizer:
@@ -20,22 +23,26 @@ class Tokenizer:
 
     SPACY_PACKAGE = "en_core_web_sm"
 
-    def __init__(self):
+    def __init__(self, debug_mode=False):
         """
         Initializes the Tokenizer class by setting up the local path
         and loading the spaCy model.
         """
-        # Get local directory
+        self.debug_mode = debug_mode
         self.local_path = get_full_data_pathway("clean_convokit/")
-        print(f"Data will be saved to: \n{self.local_path}")
+        debug_print(
+            f"Data will be saved to: \n{self.local_path}", self.debug_mode
+        )
 
         try:
             self.nlp = spacy.load(self.SPACY_PACKAGE, disable=["parser", "ner"])
         except OSError:
-            print("Spacy not present. Downloading files.")
+            debug_print(
+                "spaCy not present. Downloading package.", self.debug_mode
+            )
             spacy.cli.download(self.SPACY_PACKAGE)
             self.nlp = spacy.load(self.SPACY_PACKAGE, disable=["parser", "ner"])
-        print("Spacy module successfully loaded.")
+        debug_print("spaCy module successfully loaded.", self.debug_mode)
 
         self.tokenize()
 
@@ -66,4 +73,4 @@ class Tokenizer:
         )
         utterances_df.to_csv(self.local_path + "utterances_df.csv", index=False)
         utterances_df.to_pickle(self.local_path + "utterances_df.p")
-        print("Spacy tokenization complete.")
+        debug_print("Spacy tokenization complete.", self.debug_mode)

--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -6,7 +6,10 @@ import numpy as np
 import pandas as pd
 
 from supreme_court_predictions.util.contants import ENCODING_UTF_8
-from supreme_court_predictions.util.functions import get_full_data_pathway
+from supreme_court_predictions.util.functions import (
+    debug_print,
+    get_full_data_pathway,
+)
 
 
 class Descriptives:
@@ -15,20 +18,23 @@ class Descriptives:
     statistics of the convokit data.
     """
 
-    def __init__(self):
-        self.cases_stats = None
+    def __init__(self, debug_mode=False):
         self.advocates_stats = None
+        self.cases_stats = None
+        self.debug_mode = debug_mode
         self.speakers_stats = None
         self.utterances_stats = None
         self.voters_stats = None
 
         # Get local directory
         self.local_path = get_full_data_pathway("clean_convokit/")
-        print(f"Working in {self.local_path}")
+        debug_print(f"Working in {self.local_path}", self.debug_mode)
 
         # Set output path
         self.output_path = get_full_data_pathway("statistics/")
-        print(f"Data will be saved to {self.output_path}")
+        debug_print(
+            f"Data will be saved to {self.output_path}", self.debug_mode
+        )
 
     @staticmethod
     def fix_indices(main, sub):
@@ -300,33 +306,41 @@ class Descriptives:
 
     def parse_all_data(self):
         """
-        Calculates descriptive statistics for all of the supreme corpus
-        DataFrames and exports them to csv/excel (if applicable).
+        Calculates descriptive statistics for all supreme corpus DataFrames
+        and exports them to csv/excel (if applicable).
         """
-        print("Grabbing case descriptive statistics...")
+        debug_print("Grabbing case descriptive statistics...", self.debug_mode)
         self.cases_stats = self.get_cases_desc()
 
-        print("Grabbing advocates descriptive statistics...")
+        debug_print(
+            "Grabbing advocates descriptive statistics...", self.debug_mode
+        )
         self.advocates_stats = self.get_advocate_desc()
 
-        print("Grabbing speakers descriptive statistics...")
+        debug_print(
+            "Grabbing speakers descriptive statistics...", self.debug_mode
+        )
         self.speakers_stats = self.get_speaker_desc()
 
-        print("Grabbing voters descriptive statistics...")
+        debug_print(
+            "Grabbing voters descriptive statistics...", self.debug_mode
+        )
         self.voters_stats = self.get_voters_desc()
 
-        print("Grabbing utterances descriptive statistics...")
+        debug_print(
+            "Grabbing utterances descriptive statistics...", self.debug_mode
+        )
         self.utterances_stats = self.get_utterances_desc()
 
         # Outputting to CSVs
-        descriptives = [
+        descriptive_statistics = [
             self.advocates_stats,
             self.cases_stats,
             self.speakers_stats,
             self.voters_stats,
             self.utterances_stats,
         ]
-        outpaths = [
+        output_paths = [
             self.output_path + "/advocates_stats.csv",
             self.output_path + "/cases_stats.csv",
             self.output_path + "/speakers_stats.csv",
@@ -334,8 +348,8 @@ class Descriptives:
             self.output_path + "/utterances_stats.csv",
         ]
 
-        for idx, desc in enumerate(descriptives):
-            desc.to_csv(outpaths[idx], index=True, encoding=ENCODING_UTF_8)
+        for idx, desc in enumerate(descriptive_statistics):
+            desc.to_csv(output_paths[idx], index=True, encoding=ENCODING_UTF_8)
 
         # Outputting to a single excel
         desc_out = self.output_path + "/descriptive_statistics.xlsx"
@@ -350,4 +364,4 @@ class Descriptives:
             self.voters_stats.to_excel(writer, sheet_name="voters")
             self.utterances_stats.to_excel(writer, sheet_name="utterances")
 
-        print("Data saved to " + self.output_path)
+        debug_print("Data saved to " + self.output_path, self.debug_mode)

--- a/supreme_court_predictions/statistics/service.py
+++ b/supreme_court_predictions/statistics/service.py
@@ -6,9 +6,21 @@ from supreme_court_predictions.processing.datacleaner import DataCleaner
 from supreme_court_predictions.statistics.descriptives import Descriptives
 
 
-def clean_data():
-    DataCleaner().parse_all_data()
+def clean_data(debug_mode=False):
+    """
+    Runner function for cleaning and formatting the Convokit corpus.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    DataCleaner(debug_mode).parse_all_data()
 
 
-def describe_data():
-    Descriptives().parse_all_data()
+def describe_data(debug_mode=False):
+    """
+    Runner function for calculating the descriptive statistics.
+
+    :param bool debug_mode: Indicates if the application requires debug print
+        statements.
+    """
+    Descriptives(debug_mode).parse_all_data()

--- a/supreme_court_predictions/statistics/service.py
+++ b/supreme_court_predictions/statistics/service.py
@@ -2,18 +2,7 @@
 This file works as the central point of interaction for the statistics package.
 """
 
-from supreme_court_predictions.processing.datacleaner import DataCleaner
 from supreme_court_predictions.statistics.descriptives import Descriptives
-
-
-def clean_data(debug_mode=False):
-    """
-    Runner function for cleaning and formatting the Convokit corpus.
-
-    :param bool debug_mode: Indicates if the application requires debug print
-        statements.
-    """
-    DataCleaner(debug_mode).parse_all_data()
 
 
 def describe_data(debug_mode=False):


### PR DESCRIPTION
## Describe your changes
Created standard way of printing for application so that we `print` statements when running from the CLI, but not from the default configuration that we'll use in Jupyter notebooks.

## Checklist before requesting a review
- [x] The code runs successfully.

```
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % make get-data
python -m "supreme_court_predictions" --get-data
oh, what up?
Loading Supreme Court Corpus Data...
Dataset already exists at /Users/michaelp/.convokit/downloads/supreme-corpus
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions % make prepare-data
python -m "supreme_court_predictions" --clean-data --describe-data --tokenize-data --process-data
oh, what up?
Working in /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/convokit/
Data will be saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Parsing cases...
Parsing speakers...
Parsing conversations metadata...
Parsing utterances...
Data saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Data will be saved to: 
/Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
spaCy module successfully loaded.
^[[A^[[BSpacy tokenization complete.
Working in /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Data will be saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/statistics/
Grabbing case descriptive statistics...
Grabbing advocates descriptive statistics...
Grabbing speakers descriptive statistics...
Grabbing voters descriptive statistics...
Grabbing utterances descriptive statistics...
Data saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/statistics/
Working in /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/clean_convokit/
Data will be saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/processed/
Grabbing token aggregation for all cases...
Grabbing token aggregation for advocates...
Grabbing token aggregation for adversaries...
Grabbing token aggregation for judges...
Exporting files...
Data saved to /Users/michaelp/Documents/GitHub/supreme-court-ml-predictions/supreme_court_predictions/data/processed/
(poetry-python-project-py3.11) michaelp@MacBook-Air-3 supreme-court-ml-predictions %
...
```
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
