### PR TITLE
Add F1 Score, Confusion Matrix, and general code edits

### DIFF
--- a/second_checkpoint.ipynb
+++ b/second_checkpoint.ipynb
@@ -43,10 +43,10 @@
      "evalue": "No module named 'jupyter_black'",
      "output_type": "error",
      "traceback": [
-      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[0;31mModuleNotFoundError\u001B[0m                       Traceback (most recent call last)",
-      "Cell \u001B[0;32mIn[1], line 2\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;66;03m# Setup for data examples and plots\u001B[39;00m\n\u001B[0;32m----> 2\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mjupyter_black\u001B[39;00m\n\u001B[1;32m      3\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mmatplotlib\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mpyplot\u001B[39;00m \u001B[38;5;28;01mas\u001B[39;00m \u001B[38;5;21;01mplt\u001B[39;00m\n\u001B[1;32m      4\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m \u001B[38;5;28;01mas\u001B[39;00m \u001B[38;5;21;01mpd\u001B[39;00m\n",
-      "\u001B[0;31mModuleNotFoundError\u001B[0m: No module named 'jupyter_black'"
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Setup for data examples and plots\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mjupyter_black\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mmatplotlib\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mpyplot\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mplt\u001b[39;00m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mpandas\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mpd\u001b[39;00m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'jupyter_black'"
      ]
     }
    ],
@@ -760,7 +760,7 @@
     "\n",
     "for size in test_sizes:\n",
     "    l = LogisticRegression(test_size=size, print_results=False)\n",
-    "    accs = l.run()\n",
+    "    accs, _, _ = l.run()\n",
     "    acc1.append(accs[0])\n",
     "    acc2.append(accs[1])\n",
     "    acc3.append(accs[2])\n",
@@ -858,7 +858,7 @@
     "\n",
     "for ftr in feature_sizes:\n",
     "    l = LogisticRegression(max_features=ftr, print_results=False)\n",
-    "    accs = l.run()\n",
+    "    accs, _, _ = l.run()\n",
     "    acc1.append(accs[0])\n",
     "    acc2.append(accs[1])\n",
     "    acc3.append(accs[2])\n",
@@ -1791,7 +1791,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.1"
   }
  },
  "nbformat": 4,

--- a/supreme_court_predictions/api/convokit.py
+++ b/supreme_court_predictions/api/convokit.py
@@ -4,7 +4,7 @@ This file serves as the client for convokit.
 import requests
 from convokit import Corpus, download
 
-from supreme_court_predictions.util.contants import (
+from supreme_court_predictions.util.constants import (
     ENCODING_UTF_8,
     FILE_MODE_WRITE,
 )

--- a/supreme_court_predictions/models/logistic_regression.py
+++ b/supreme_court_predictions/models/logistic_regression.py
@@ -36,12 +36,12 @@ class LogisticRegression(Model):
         test_size=0.20,
     ):
         # Model outputs
-        self.accuracies = []
-        self.f1 = []
+        self.accuracies = {}
+        self.f1 = {}
+        self.confusion_matrix = {}
+        self.models = {}
         self.dataframes = []
         self.dataframe_names = []
-        self.confusion_matrix = []
-        self.models = []
 
         # Data and display
         self.debug_mode = debug_mode
@@ -109,10 +109,10 @@ class LogisticRegression(Model):
         for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
                 model, acc, f1, cm = self.create_and_measure(df)
-                self.models.append(model)
-                self.accuracies.append(acc)
-                self.f1.append(f1)
-                self.confusion_matrix.append(cm)
+                self.models[df_name] = model
+                self.accuracies[df_name] = acc
+                self.f1[df_name] = f1
+                self.confusion_matrix[df_name] = cm
 
                 # Print the results, if applicable
                 self.print_results(self.name.lower(), acc, f1, df_name)
@@ -145,11 +145,11 @@ class LogisticRegression(Model):
             return_str += f"\t{name}: {str(parameter)}\n"
 
         return_str += "ACCURACIES: \n"
-        for name, acc in zip(self.dataframe_names, self.accuracies):
+        for name, acc in self.accuracies.items():
             return_str += f"\t{name}: {str(acc)}\n"
 
         return_str += "F1 SCORES: "
-        for name, f1 in zip(self.dataframe_names, self.f1):
+        for name, f1 in self.f1.items():
             return_str += f"\n\t{name}: {str(f1)}"
 
         return return_str

--- a/supreme_court_predictions/models/logistic_regression.py
+++ b/supreme_court_predictions/models/logistic_regression.py
@@ -9,11 +9,10 @@ import os.path
 import pandas as pd
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression as skLR
-from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
 from supreme_court_predictions.models.model import Model
-from supreme_court_predictions.util.contants import SEED_CONSTANT
+from supreme_court_predictions.util.constants import SEED_CONSTANT
 from supreme_court_predictions.util.functions import get_full_data_pathway
 
 
@@ -36,11 +35,19 @@ class LogisticRegression(Model):
         max_iter=1000,
         test_size=0.20,
     ):
+        # Model outputs
         self.accuracies = []
+        self.f1 = []
         self.dataframes = []
         self.dataframe_names = []
+        self.confusion_matrix = []
+        self.models = []
+
+        # Data and display
         self.debug_mode = debug_mode
         self.local_path = get_full_data_pathway("processed/")
+
+        # Model features
         self.max_features = max_features
         self.max_iter = max_iter
         self.name = "Regression"
@@ -101,11 +108,14 @@ class LogisticRegression(Model):
 
         for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
-                acc = self.create_and_measure(df, accuracy_score)
+                model, acc, f1, cm = self.create_and_measure(df)
+                self.models.append(model)
                 self.accuracies.append(acc)
+                self.f1.append(f1)
+                self.confusion_matrix.append(cm)
 
                 # Print the results, if applicable
-                self.print_results(self.name.lower(), acc, df_name)
+                self.print_results(self.name.lower(), acc, f1, df_name)
             except ValueError:
                 self.print("------------------------------------------")
                 self.print(
@@ -113,7 +123,7 @@ class LogisticRegression(Model):
                 )
                 self.print("------------------------------------------")
 
-        return self.accuracies
+        return self.accuracies, self.f1, self.confusion_matrix
 
     def __repr__(self):
         """
@@ -134,8 +144,12 @@ class LogisticRegression(Model):
         for parameter, name in zip(parameters, parameter_names):
             return_str += f"\t{name}: {str(parameter)}\n"
 
-        return_str += "ACCURACIES: "
+        return_str += "ACCURACIES: \n"
         for name, acc in zip(self.dataframe_names, self.accuracies):
-            return_str += f"\n\t{name}: {str(acc)}"
+            return_str += f"\t{name}: {str(acc)}\n"
+
+        return_str += "F1 SCORES: "
+        for name, f1 in zip(self.dataframe_names, self.f1):
+            return_str += f"\n\t{name}: {str(f1)}"
 
         return return_str

--- a/supreme_court_predictions/models/model.py
+++ b/supreme_court_predictions/models/model.py
@@ -4,6 +4,8 @@ This file contains the class that is the basis for all models in this package.
 
 from abc import ABC, abstractmethod
 
+from sklearn.metrics import accuracy_score, confusion_matrix, f1_score
+
 from supreme_court_predictions.util.functions import debug_print
 
 
@@ -21,18 +23,25 @@ class Model(ABC):
         :return: A sklearn model.
         """
 
-    def create_and_measure(self, df, accuracy_measure):
+    def create_and_measure(self, df):
         """
         Takes in a dataframe and returns the applicable accuracy measurement.
 
         :param pandas.DataFrame df: A dataframe used to create the model.
         :param function accuracy_measure: A function that is used to measure
         accuracy on the model.
-        :return: Float of some accuracy measurement.
+        :return: Float of accuracy.
+        :return: Float of F1 score.
+        :return: Confusion matrix for model
         """
-        _, y_test, y_pred = self.create(df)
+        model, y_test, y_pred = self.create(df)
 
-        return accuracy_measure(y_true=y_test, y_pred=y_pred)
+        return (
+            model,
+            accuracy_score(y_true=y_test, y_pred=y_pred),
+            f1_score(y_true=y_test, y_pred=y_pred),
+            confusion_matrix(y_true=y_test, y_pred=y_pred),
+        )
 
     @abstractmethod
     def run(self):
@@ -56,7 +65,11 @@ class Model(ABC):
         """
 
     def print_results(
-        self, model_name="", accuracy_score=None, dataframe_name=None
+        self,
+        model_name="",
+        accuracy_score=None,
+        f1_score=None,
+        dataframe_name=None,
     ):
         """
         Prints the results of running the model.
@@ -71,4 +84,5 @@ class Model(ABC):
             print("------------------------------------------")
             print(f"Running a {model_name} on {dataframe_name}...")
             print(f"Accuracy score: {accuracy_score}")
+            print(f"F1 score: {f1_score}")
             print("------------------------------------------")

--- a/supreme_court_predictions/models/random_forest.py
+++ b/supreme_court_predictions/models/random_forest.py
@@ -31,10 +31,10 @@ class RandomForest(Model):
         test_size=0.20,
     ):
         # Model outputs
-        self.accuracies = []
-        self.f1 = []
-        self.confusion_matrix = []
-        self.models = []
+        self.accuracies = {}
+        self.f1 = {}
+        self.confusion_matrix = {}
+        self.models = {}
 
         # Data and display
         self.debug_mode = debug_mode
@@ -109,10 +109,10 @@ class RandomForest(Model):
         for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
                 model, acc, f1, cm = self.create_and_measure(df)
-                self.models.append(model)
-                self.accuracies.append(acc)
-                self.f1.append(f1)
-                self.confusion_matrix.append(cm)
+                self.models[df_name] = model
+                self.accuracies[df_name] = acc
+                self.f1[df_name] = f1
+                self.confusion_matrix[df_name] = cm
 
                 # Print the results, if applicable
                 self.print_results(self.name.lower(), acc, f1, df_name)
@@ -151,11 +151,11 @@ class RandomForest(Model):
             return_str += f"\t{name}: {str(parameter)}\n"
 
         return_str += "ACCURACIES: \n"
-        for name, acc in zip(self.dataframe_names, self.accuracies):
+        for name, acc in self.accuracies.items():
             return_str += f"\t{name}: {str(acc)}\n"
 
         return_str += "F1 SCORES: "
-        for name, f1 in zip(self.dataframe_names, self.f1):
+        for name, f1 in self.f1.items():
             return_str += f"\n\t{name}: {str(f1)}"
 
         return return_str

--- a/supreme_court_predictions/models/random_forest.py
+++ b/supreme_court_predictions/models/random_forest.py
@@ -3,11 +3,10 @@ import os.path
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
 from supreme_court_predictions.models.model import Model
-from supreme_court_predictions.util.contants import SEED_CONSTANT
+from supreme_court_predictions.util.constants import SEED_CONSTANT
 from supreme_court_predictions.util.functions import get_full_data_pathway
 
 
@@ -31,9 +30,17 @@ class RandomForest(Model):
         num_trees=100,
         test_size=0.20,
     ):
+        # Model outputs
         self.accuracies = []
+        self.f1 = []
+        self.confusion_matrix = []
+        self.models = []
+
+        # Data and display
         self.debug_mode = debug_mode
         self.local_path = get_full_data_pathway("processed/")
+
+        # Model features
         self.max_depth = max_depth
         self.max_features = max_features
         self.name = "Random Forest"
@@ -101,11 +108,14 @@ class RandomForest(Model):
 
         for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
-                acc = self.create_and_measure(df, accuracy_score)
+                model, acc, f1, cm = self.create_and_measure(df)
+                self.models.append(model)
                 self.accuracies.append(acc)
+                self.f1.append(f1)
+                self.confusion_matrix.append(cm)
 
                 # Print the results, if applicable
-                self.print_results(self.name.lower(), acc, df_name)
+                self.print_results(self.name.lower(), acc, f1, df_name)
             except ValueError:
                 self.print("------------------------------------------")
                 self.print(
@@ -113,7 +123,7 @@ class RandomForest(Model):
                 )
                 self.print("------------------------------------------")
 
-        return self.accuracies
+        return self.accuracies, self.f1, self.confusion_matrix
 
     def __repr__(self):
         """
@@ -140,8 +150,12 @@ class RandomForest(Model):
         for parameter, name in zip(parameters, parameter_names):
             return_str += f"\t{name}: {str(parameter)}\n"
 
-        return_str += "ACCURACIES: "
+        return_str += "ACCURACIES: \n"
         for name, acc in zip(self.dataframe_names, self.accuracies):
-            return_str += f"\n\t{name}: {str(acc)}"
+            return_str += f"\t{name}: {str(acc)}\n"
+
+        return_str += "F1 SCORES: "
+        for name, f1 in zip(self.dataframe_names, self.f1):
+            return_str += f"\n\t{name}: {str(f1)}"
 
         return return_str

--- a/supreme_court_predictions/models/xg_boost.py
+++ b/supreme_court_predictions/models/xg_boost.py
@@ -43,17 +43,17 @@ class XGBoost(Model):
         subsample=1,
     ):
         # Model outputs
-        self.accuracies = []
-        self.f1 = []
-        self.models = []
+        self.accuracies = {}
+        self.f1 = {}
+        self.models = {}
+        self.confusion_matrix = {}
+        self.dataframes = []
+        self.dataframe_names = []
+
+        # Data and display
         self.debug_mode = debug_mode
         self.local_path = get_full_data_pathway("processed/")
         self.name = "Gradient Boosted Tree Model"
-        self.confusion_matrix = []
-
-        # Dataframes and df names to run models against
-        self.dataframes = []
-        self.dataframe_names = []
 
         # Parameters (model and others)
         self.max_features = max_features
@@ -130,10 +130,10 @@ class XGBoost(Model):
         for df, df_name in zip(self.dataframes, self.dataframe_names):
             try:
                 model, acc, f1, cm = self.create_and_measure(df)
-                self.models.append(model)
-                self.accuracies.append(acc)
-                self.f1.append(f1)
-                self.confusion_matrix.append(cm)
+                self.models[df_name] = model
+                self.accuracies[df_name] = acc
+                self.f1[df_name] = f1
+                self.confusion_matrix[df_name] = cm
 
                 # Print the results, if applicable
                 self.print_results(self.name.lower(), acc, f1, df_name)
@@ -177,11 +177,11 @@ class XGBoost(Model):
             return_str += f"\t{name}: {str(parameter)}\n"
 
         return_str += "ACCURACIES: \n"
-        for name, acc in zip(self.dataframe_names, self.accuracies):
+        for name, acc in self.accuracies.items():
             return_str += f"\t{name}: {str(acc)}\n"
 
         return_str += "F1 SCORES: "
-        for name, f1 in zip(self.dataframe_names, self.f1):
+        for name, f1 in self.f1.items():
             return_str += f"\n\t{name}: {str(f1)}"
 
         return return_str

--- a/supreme_court_predictions/processing/datacleaner.py
+++ b/supreme_court_predictions/processing/datacleaner.py
@@ -9,7 +9,7 @@ import re
 import pandas as pd
 from convokit import Corpus, download
 
-from supreme_court_predictions.util.contants import (
+from supreme_court_predictions.util.constants import (
     ENCODING_UTF_8,
     FILE_MODE_READ,
     LATEST_YEAR,

--- a/supreme_court_predictions/statistics/descriptives.py
+++ b/supreme_court_predictions/statistics/descriptives.py
@@ -5,7 +5,7 @@ statistics for the convokit datasets.
 import numpy as np
 import pandas as pd
 
-from supreme_court_predictions.util.contants import ENCODING_UTF_8
+from supreme_court_predictions.util.constants import ENCODING_UTF_8
 from supreme_court_predictions.util.functions import (
     debug_print,
     get_full_data_pathway,

--- a/supreme_court_predictions/util/constants.py
+++ b/supreme_court_predictions/util/constants.py
@@ -2,6 +2,8 @@
 This file holds constants that will be used throughout the application.
 """
 
+import numpy as np
+
 ENCODING_UTF_8 = "utf-8"
 
 # sklearn things
@@ -13,3 +15,6 @@ FILE_MODE_WRITE = "w"
 
 # Current year for data filtering
 LATEST_YEAR = 2019
+
+# Labels for ML models
+LABELS = np.array(["for petitioner", "for respondent"])


### PR DESCRIPTION

## Describe your changes
Added functionality for calculating the F1 score, confusion matrices, and fixed the `__repr__()` function for XGBoost.

## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] The code runs successfully.

```
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make format
isort "supreme_court_predictions"/ test/
Skipped 1 files
black "supreme_court_predictions"/ test/ *.ipynb
All done! ✨ 🍰 ✨
25 files left unchanged.
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make lint
ruff "supreme_court_predictions"/ test/
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make test
pytest -vs test/
========================================= test session starts ==========================================
platform darwin -- Python 3.11.1, pytest-7.3.1, pluggy-1.0.0 -- /Users/shaymilner/Library/Caches/pypoetry/virtualenvs/supreme-court-predictions-sGlGetDh-py3.11/bin/python
cachedir: .pytest_cache
rootdir: /Users/shaymilner/Documents/Harris/Spring23/Machine_Learning/final_project/supreme-court-ml-predictions
plugins: anyio-3.6.2
collected 1 item                                                                                       

test/test_util.py::test_get_full_pathway PASSED

========================================== 1 passed in 0.00s ===========================================

```
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
