### PR TITLE
Added count of advocates and case year to DFs

### DIFF
--- a/supreme_court_predictions/models/logistic_regression.py
+++ b/supreme_court_predictions/models/logistic_regression.py
@@ -84,8 +84,21 @@ class LogisticRegression(Model):
 
         bag_of_words_y = df.loc[:, "win_side"]
 
+        # Append bag of words to other attributes in df
+        new_df = df.drop(columns=["case_id", "tokens", "win_side"])
+        new_df = pd.concat(
+            [
+                new_df,
+                pd.DataFrame(
+                    bag_of_words_x.toarray(),
+                    columns=vectorizer.get_feature_names_out(),
+                ),
+            ],
+            axis=1,
+        )
+
         X_train, X_test, y_train, y_test = train_test_split(
-            bag_of_words_x,
+            new_df,
             bag_of_words_y,
             test_size=self.test_size,
             random_state=SEED_CONSTANT,

--- a/supreme_court_predictions/models/random_forest.py
+++ b/supreme_court_predictions/models/random_forest.py
@@ -82,8 +82,21 @@ class RandomForest(Model):
 
         bag_of_words_y = df.loc[:, "win_side"]
 
+        # Append bag of words to other attributes in df
+        new_df = df.drop(columns=["case_id", "tokens", "win_side"])
+        new_df = pd.concat(
+            [
+                new_df,
+                pd.DataFrame(
+                    bag_of_words_x.toarray(),
+                    columns=vectorizer.get_feature_names_out(),
+                ),
+            ],
+            axis=1,
+        )
+
         X_train, X_test, y_train, y_test = train_test_split(
-            bag_of_words_x,
+            new_df,
             bag_of_words_y,
             test_size=self.test_size,
             random_state=SEED_CONSTANT,

--- a/supreme_court_predictions/models/xg_boost.py
+++ b/supreme_court_predictions/models/xg_boost.py
@@ -95,8 +95,21 @@ class XGBoost(Model):
         bag_of_words_x = vectorizer.fit_transform(vectorize_document)
         bag_of_words_y = df.loc[:, "win_side"]
 
+        # Append bag of words to other attributes in df
+        new_df = df.drop(columns=["case_id", "tokens", "win_side"])
+        new_df = pd.concat(
+            [
+                new_df,
+                pd.DataFrame(
+                    bag_of_words_x.toarray(),
+                    columns=vectorizer.get_feature_names_out(),
+                ),
+            ],
+            axis=1,
+        )
+
         X_train, X_test, y_train, y_test = train_test_split(
-            bag_of_words_x,
+            new_df,
             bag_of_words_y,
             test_size=self.test_size,
             random_state=SEED_CONSTANT,


### PR DESCRIPTION
## Describe your changes
In the processed dataframes run against the models, I added the count of advocates or adversaries to the judges dataframe, and I added the case year to all of the dataframes. These extra variables are then passed through the three models in addition to the bag of words.

## Checklist before requesting a review
<!--- These are suggested things you could add, but what you add will be dependent on your repository's standards. --->
- [x] The code runs successfully.

```
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make format
isort "supreme_court_predictions"/ test/
Skipped 1 files
black "supreme_court_predictions"/ test/ *.ipynb
reformatted /Users/shaymilner/Documents/Harris/Spring23/Machine_Learning/final_project/supreme-court-ml-predictions/supreme_court_predictions/models/random_forest.py

All done! ✨ 🍰 ✨
1 file reformatted, 24 files left unchanged.
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make lint
ruff "supreme_court_predictions"/ test/
(supreme-court-predictions-py3.11) shaymilner@MacBook-Air-4 supreme-court-ml-predictions % make test
pytest -vs test/
================== test session starts ===================
platform darwin -- Python 3.11.1, pytest-7.3.1, pluggy-1.0.0 -- /Users/shaymilner/Library/Caches/pypoetry/virtualenvs/supreme-court-predictions-sGlGetDh-py3.11/bin/python
cachedir: .pytest_cache
rootdir: /Users/shaymilner/Documents/Harris/Spring23/Machine_Learning/final_project/supreme-court-ml-predictions
plugins: anyio-3.6.2
collected 1 item                                         

test/test_util.py::test_get_full_pathway PASSED

=================== 1 passed in 0.01s ====================
```
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
